### PR TITLE
Remove foxy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ ROS2 Mecanum wheel robot
 
 #### Prerequisites
 This project is build and tested on Ubuntu 22.04 LTS with ROS 2 Humble LTS.  
-For ROS 2 Foxy on Ubuntu 20.04 LTS see: [Branch: Foxy](https://github.com/deborggraever/ros2-mecanum-bot/tree/foxy)
 * [ROS install instructions](https://docs.ros.org/en/humble/Installation/Ubuntu-Install-Debians.html)
 * [Colcon install instructions](https://docs.ros.org/en/humble/Tutorials/Beginner-Client-Libraries/Colcon-Tutorial.html)
 


### PR DESCRIPTION
## Description
Remove ROS2 Foxy support due to EOL.  
See: [REP-2000](https://www.ros.org/reps/rep-2000.html)

## Type of change
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
